### PR TITLE
Roompicks amendment passed 2/25/2018

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -225,10 +225,10 @@ the Secretary.
 \item The President may have himself counted as a double occupant.
 \item Entire rooms shall be guaranteed to the following officers:
 \begin{enumerate}
-\item In order of preference, President, Vice President, Secretary, Treasurer, Librarian, Social Team including the Social Chairman (up to three members), Athletic Team including the Athletic Manager (up to two members), Head UCC, On Campus UCCs (one member per alley), Peer Advocates, IHC Chairman, ASCIT President, BoC Chair, House-elected BoC Representatives (up to two members), O’Domhnaill’s Suppliers (up to two members), House Head Waiter (one member), House BFD editors (one member), House Historians (one member)
+\item In order of preference, President, Vice President, Secretary, Treasurer, Librarian, Social Team including the Social Chairman (up to three members), Athletic Team including the Athletic Manager (up to two members), Head UCC, On Campus UCCs (one member per alley), Peer Advocates, House-elected BoC Representatives (up to two members), O’Domhnaill’s Suppliers (up to two members), House Head Waiter (one member), House BFD editors (one member), House Historians (one member), IHC Chairman.
 \item for the entire academic year following the election or appointment provided the officer completes his term. If an officer quits his office mid-term, the room guarantee shall transfer to the succeeding officeholder for the remainder of the guarantee term.
 \end{enumerate}
-\item The officer room pick order shall be President, Vice President, Secretary, Treasurer, Librarian, Social Chairman, Athletic Manager, Head UCC, On Campus UCCs, IHC Chairman, ASCIT President, BoC Chair, Social Team, Athletic Team, House-elected BoC Representatives (up to two members), O’Domhnaill’s Suppliers (up to two members), House Head Waiter (one member), House BFD editors (one member), House Historians (one member).
+\item The officer room pick order shall be President, Vice President, Secretary, Treasurer, Librarian, Social Chairman, Athletic Manager, Head UCC, On Campus UCCs, Social Team, Athletic Team, House-elected BoC Representatives (up to two members), O’Domhnaill’s Suppliers (up to two members), House Head Waiter (one member), House BFD editors (one member), House Historians (one member), IHC Chairman.
 \item All Full Members who have picked into a room through a room hassle under 7.1.2a or 7.1.2b shall be guaranteed the same room upon their return from Study Abroad.
 \end{enumerate}
 \section{Amendments}


### PR DESCRIPTION
 Proposed 2/5/2018 by Karim Lakhani, passed 2/25/2018. Removed ASCIT President and BoC Chair room picks and moved IHC Chair room pick to end of officer pick order.